### PR TITLE
Enable building with MKDEBUG and MKDEBUGLIB

### DIFF
--- a/external/mit/libXt/dist/src/Convert.c
+++ b/external/mit/libXt/dist/src/Convert.c
@@ -514,7 +514,7 @@ void _XtConverterCacheStats(void)
 	    }
 	    (void) fprintf(stdout, "Index: %4d  Entries: %d\n", i, entries);
 	    for (p = cacheHashTable[i]; p; p = p->next) {
-		(void) fprintf(stdout, "    Size: %3d  Refs: %3d  '",
+		(void) fprintf(stdout, "    Size: %3d  Refs: %3ld  '",
 			       p->from.size,
 			       p->has_ext ? CEXT(p)->ref_count : 0);
 		(void) fprintf(stdout, "'\n");

--- a/external/mit/libXt/dist/src/ResConfig.c
+++ b/external/mit/libXt/dist/src/ResConfig.c
@@ -903,10 +903,10 @@ _XtResourceConfigurationEH (
 	XtPerDisplay	pd;
 
 #ifdef DEBUG
-	fprintf (stderr, "in _XtResourceConfiguationEH atom = %d\n",event->xproperty.atom);
-	fprintf (stderr, "    window = %x\n", XtWindow (w));
+	fprintf (stderr, "in _XtResourceConfiguationEH atom = %lu\n",event->xproperty.atom);
+	fprintf (stderr, "    window = %lu\n", XtWindow (w));
 	if (XtIsWidget (w))
-		fprintf (stderr, "    widget = %x   name = %s\n", w, w->core.name);
+		fprintf (stderr, "    widget = %p   name = %s\n", w, w->core.name);
 #endif
 
 	pd = _XtGetPerDisplay (XtDisplay (w));
@@ -981,7 +981,7 @@ _XtResourceConfigurationEH (
 				resource = XtNewString (data_ptr);
 				value = XtNewString (data_value);
 #ifdef DEBUG
-				fprintf (stderr, "resource_len=%d\n",
+				fprintf (stderr, "resource_len=%lu\n",
 					 resource_len);
 				fprintf (stderr, "resource = %s\t value = %s\n",
 					 resource, value);

--- a/external/mit/libxkbui/dist/src/XKBui.c
+++ b/external/mit/libxkbui/dist/src/XKBui.c
@@ -96,7 +96,7 @@ XkbDescPtr	xkb;
 	if (XAllocNamedColor(view->dpy,view->opts.cmap,spec,&sdef,&xdef)) {
 	    xkb->geom->colors[i].pixel= sdef.pixel;
 #ifdef DEBUG
-	    fprintf(stderr,"got pixel %d for \"%s\"\n",sdef.pixel,spec);
+	    fprintf(stderr,"got pixel %lu for \"%s\"\n",sdef.pixel,spec);
 #endif
 	    found= True;
 	}
@@ -108,7 +108,7 @@ XkbDescPtr	xkb;
 	    if (XAllocNamedColor(view->dpy,view->opts.cmap,buf,&sdef,&xdef)) {
 		xkb->geom->colors[i].pixel= sdef.pixel;
 #ifdef DEBUG
-		fprintf(stderr,"got pixel %d for \"%s\"\n",sdef.pixel,spec);
+		fprintf(stderr,"got pixel %lu for \"%s\"\n",sdef.pixel,spec);
 #endif
 		found= True;
 	    }


### PR DESCRIPTION
Some small fixes in debugging code so that X11 can be built with `MKDEBUG` and `MKDEBUGLIB`.
